### PR TITLE
Added batching

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -21,7 +21,7 @@ func main() {
 	err := tracker.Track(
 		context.Background(),
 		schema.Info,
-		&schema.Identity{CustomerPersonId: "abc"},
+		&schema.Identity{CustomerPersonId: trackers.CustomerPersonIDFromAccountNumber("0000000")},
 		[]trackers.Event{
 			&schema.HomeInsuranceQuoteAttemptedEvent{
 				QuoteId:        "abc",

--- a/tracker.go
+++ b/tracker.go
@@ -35,6 +35,17 @@ type Tracker interface {
 	) error
 }
 
+type BulkTracker interface {
+	BulkTrack(ctx context.Context, batches []Batch) error
+}
+
+type Batch struct {
+	Schema     SchemaInfo
+	Identity   Identity
+	Events     []Event
+	Attributes []Attribute
+}
+
 var (
 	accountNSUUID = uuid.NewSHA1(uuid.UUID{}, []byte("customer"))
 	personNSUUID  = uuid.NewSHA1(uuid.UUID{}, []byte("person"))


### PR DESCRIPTION
This adds batching capabilities to the library. It currently supports pushing multiple events and attributes but they are all associated with a single profile/identity. This is fine but does not scale for backend processes which bulk update attributes across multiple profiles.

A new interface is introduced to make the change backwards compatible. Mparticle supports this [out of the box](https://docs.mparticle.com/developers/server/http/#v2bulkevents).