### PR TITLE
Defined NoSchema var

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then an event can be tracked by calling the `track` method.
 ```go
 err := tracker.Track(
 		context.Background(),
-		schema.Info,
+		trackers.NoSchema,
 		&schema.Identity{CustomerPersonId: trackers.CustomerPersonIDFromAccountNumber("0000000")},
 		[]trackers.Event{
 			&schema.HomeInsuranceQuoteAttemptedEvent{

--- a/example/example.go
+++ b/example/example.go
@@ -20,7 +20,8 @@ func main() {
 
 	err := tracker.Track(
 		context.Background(),
-		schema.Info,
+		// do not pass in schema to avoid errors in the mparticle dashboard because we currently don't have any plans configured in mparticle
+		trackers.NoSchema,
 		&schema.Identity{CustomerPersonId: trackers.CustomerPersonIDFromAccountNumber("0000000")},
 		[]trackers.Event{
 			&schema.HomeInsuranceQuoteAttemptedEvent{

--- a/mparticle/tracker.go
+++ b/mparticle/tracker.go
@@ -139,18 +139,19 @@ func toMParticleBatch(schema trackers.SchemaInfo,
 	attribs []trackers.Attribute,
 	env events.Environment) events.Batch {
 	batch := events.Batch{
-		Environment: env,
-		BatchContext: &events.BatchContext{
-			DataPlan: &events.DataPlanContext{
-				PlanID:      schema.Name(),
-				PlanVersion: schema.Version(),
-			},
-		},
+		Environment:    env,
 		UserIdentities: buildIdentity(identity.Map()),
 		UserAttributes: make(map[string]interface{}),
 		Events:         []events.Event{},
 	}
-
+	if schema != trackers.NoSchema {
+		batch.BatchContext = &events.BatchContext{
+			DataPlan: &events.DataPlanContext{
+				PlanID:      schema.Name(),
+				PlanVersion: schema.Version(),
+			},
+		}
+	}
 	for _, x := range evs {
 		customEvent := events.NewCustomEvent()
 		customEvent.Data.EventName = x.Name()

--- a/tracker.go
+++ b/tracker.go
@@ -11,6 +11,18 @@ type SchemaInfo interface {
 	Version() int64
 }
 
+type schema string
+
+func (o schema) Name() string {
+	return ""
+}
+
+func (o schema) Version() int64 {
+	return -1
+}
+
+const NoSchema = schema("")
+
 type Event interface {
 	Payload() map[string]string
 	Name() string


### PR DESCRIPTION
Defined a new `SchemaInfo` variable called `NoSchema`. This will get rid of the `No plan found` error in the mparticle dashboard.

We currently don't have any plans defined in mparticle to enforce validation on incoming events and we can't configure them because of technical limitations with how plans work in mparticle. This means every event pushed to mparticle will result in an error in the mparticle dashboard. While this error is harmless because validation is disabled, it tends to confuse people and make them question the correctness of the events.