### PR TITLE
Allow schema name & version from payload

### DIFF
--- a/mparticle/tracker.go
+++ b/mparticle/tracker.go
@@ -158,9 +158,12 @@ func toMParticleBatch(schema trackers.SchemaInfo,
 		customEvent.Data.CustomEventType = events.OtherCustomEventType
 		customEvent.Data.CustomAttributes = x.Payload()
 
-		//attach some event ID data as custom flags
-		customEvent.Data.CustomAttributes["uw.schema-name"] = schema.Name()
-		customEvent.Data.CustomAttributes["uw.schema-version"] = strconv.FormatInt(schema.Version(), 10)
+		if customEvent.Data.CustomAttributes["uw.schema-name"] == "" {
+			customEvent.Data.CustomAttributes["uw.schema-name"] = schema.Name()
+		}
+		if customEvent.Data.CustomAttributes["uw.schema-version"] == "" {
+			customEvent.Data.CustomAttributes["uw.schema-version"] = strconv.FormatInt(schema.Version(), 10)
+		}
 
 		batch.Events = append(batch.Events, customEvent)
 	}


### PR DESCRIPTION
We introduced `trackers.NoSchema` in order to remove `No plan found` error in the mparticle dashboard at the batch level, but that meant the schema information we generated is lost from the event payload.

Custom schema information comes through into mParticle blanked.

```
uw.schema-name: ''
uw.schema-version: '-1'
```

The generated Go code sets this already within the payload
https://github.com/utilitywarehouse/cbc-mparticle/blob/master/internal/schema/schema.go#L88-L89
